### PR TITLE
Added null check to ATOM updated date parsing

### DIFF
--- a/QDFeedParser/Xml/LinqFeedXmlParser.cs
+++ b/QDFeedParser/Xml/LinqFeedXmlParser.cs
@@ -70,9 +70,12 @@ namespace QDFeedParser.Xml
 
             var dateTimeNode = channel.Element(Atom10Namespace + "updated");
 
-            DateTime timeOut;
-            DateTime.TryParse(dateTimeNode.Value, out timeOut);
-            atomFeed.LastUpdated = timeOut.ToUniversalTime();
+	        if (dateTimeNode != null)
+	        {
+				DateTime timeOut;
+				DateTime.TryParse(dateTimeNode.Value, out timeOut);
+				atomFeed.LastUpdated = timeOut.ToUniversalTime();
+	        }
 
             var generatorNode = channel.Element(Atom10Namespace + "generator");
             atomFeed.Generator = generatorNode == null ? string.Empty : generatorNode.Value;


### PR DESCRIPTION
Added null check to ATOM updated date parsing to avoid a
NullReferenceException that occurs when the updated element does not
exist.
